### PR TITLE
security: update jsPDF 4.1.0 -> 4.2.0 (CVE fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Alle Abhängigkeiten werden über CDN geladen – es gibt **keine lokalen node_m
 |---|---|---|
 | [Font Awesome](https://fontawesome.com/) | 6.5.1 | Icons |
 | [@hpcc-js/wasm (Graphviz)](https://github.com/nicedoc/hpcc-js-wasm) | latest | DOT-Rendering im Browser (Angriffsbäume) |
-| [jsPDF](https://github.com/parallax/jsPDF) | 2.5.1 | PDF-Report-Generierung |
+| [jsPDF](https://github.com/parallax/jsPDF) | 4.2.0 | PDF-Report-Generierung |
 
 Für die PDF-Angriffsbaumvisualisierung werden externe Render-Dienste genutzt:
 - [Kroki](https://kroki.io/) (primär)

--- a/index.html
+++ b/index.html
@@ -446,7 +446,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
     <!-- Report (PDF) -->
-    <script src="https://cdn.jsdelivr.net/npm/jspdf@4.1.0/dist/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@4.2.0/dist/jspdf.umd.min.js"></script>
     <script src="js/report/report_pdf_helpers.js"></script>
     <script src="js/report/report_pdf_builder.js"></script>
     <script src="js/report/report_export.js"></script>

--- a/js/core/about.js
+++ b/js/core/about.js
@@ -88,14 +88,14 @@ function generateCycloneDxSbom() {
             {
                 "type": "library",
                 "name": "jsPDF",
-                "version": "2.5.1",
+                "version": "4.2.0",
                 "description": "Client-seitige PDF-Generierung – Erzeugung des TARA-PDF-Reports",
                 "licenses": [{ "license": { "id": "MIT" } }],
-                "purl": "pkg:npm/jspdf@2.5.1",
+                "purl": "pkg:npm/jspdf@4.2.0",
                 "scope": "required",
                 "externalReferences": [
                     { "type": "website",      "url": "https://github.com/parallax/jsPDF" },
-                    { "type": "distribution", "url": "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" }
+                    { "type": "distribution", "url": "https://cdn.jsdelivr.net/npm/jspdf@4.2.0/dist/jspdf.umd.min.js" }
                 ]
             },
             {


### PR DESCRIPTION
## jsPDF Security Update

Updates jsPDF from 4.1.0 to 4.2.0 to fix 3 critical CVEs:

- **CVE-2026-25535** (CVSS 8.7): DoS via Malicious GIF
- **CVE-2026-25755** (CVSS 8.1): PDF Object Injection via addJS
- **CVE-2026-25940** (CVSS 8.1): PDF Injection in AcroForm

### Changes
- `index.html`: CDN reference 4.1.0 -> 4.2.0
- `js/core/about.js`: SBOM version + purl + URL updated
- `README.md`: Version 2.5.1 -> 4.2.0

### Testing
All **238 tests passed** (pytest + Playwright/Chromium, 12:47 runtime).

Closes #15